### PR TITLE
Adds a database init script

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,14 @@ perl Makefile.PL
 make manifest
 make rpm
 > resourcedb-0.0.1-1.el7.centos.noarch.rpm
+sudo yum install resourcedb-0.0.1-1.el7.centos.noarch.rpm
+```
+
+If this is your first time running ResourceDB use the database init
+script to create the database configuration. The generated
+configuration file will be stored at
+`/etc/grnoc/resourcedb/config.xml`.
+
+```
+sudo resourcedb-init-db
 ```

--- a/bin/resourcedb-init-db
+++ b/bin/resourcedb-init-db
@@ -1,0 +1,56 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use DBI;
+
+use GRNOC::CLI;
+
+sub main {
+    my $cli = GRNOC::CLI->new();
+
+    my $user = $cli->get_input("Database username", default => "root");
+    my $pass = $cli->get_password("Database password");
+    my $host = $cli->get_input("Database host address", default => "127.0.0.1");
+    my $port = $cli->get_input("Database Port number", default => 3306);
+
+    my $handle = DBI->connect("DBI:mysql:dbname=mysql;host=$host;port=$port",
+                              $user,
+                              $pass,
+                              {PrintError => 0});
+    if (!$handle) {
+        warn "Couldn't connect to database: " . $DBI::errstr . "\n";
+        exit 1;
+    }
+
+    print "Connected to database.\n";
+
+    my $alpha = undef;
+    my $bravo = undef;
+    while (1) {
+        $alpha = $cli->get_password("rdb user password");
+        $bravo = $cli->get_password("rdb user password confirmation");
+
+        last if ($alpha eq $bravo);
+        print "Passwords do not match. Please try again.\n";
+    }
+
+    $handle->do("GRANT ALL ON resourcedb.* to 'rdb'\@'localhost' identified by '$alpha'") or die DBI::errstr;
+    $handle->do("GRANT ALL ON resourcedbtest.* to 'rdb'\@'localhost' identified by '$alpha'") or die DBI::errstr;
+    $handle->do("flush privileges");
+
+    print "ResourceDB's database user was created.\n";
+
+    `/bin/mkdir -p /etc/grnoc/resourcedb/`;
+    open(FILE, "> /etc/grnoc/resourcedb/config.xml");
+    print FILE << "END";
+<config>
+  <db name="resourcedb" username="rdb" password="$alpha" port="$port" host="$host" schema="/etc/grnoc/resouredb/resourcedb.sql"/>
+</config>
+END
+
+    return 1;
+}
+
+main();

--- a/resourcedb.spec
+++ b/resourcedb.spec
@@ -14,6 +14,10 @@ BuildRequires: perl
 BuildRequires: httpd-devel
 BuildRequires: mod_perl-devel
 
+Requires: mariadb
+Requires: mariadb-server
+Requires: perl-DBD-MySQL
+
 %description
 NetSage Resource Database (Science Registry)
 
@@ -24,15 +28,28 @@ NetSage Resource Database (Science Registry)
 %{__perl} Makefile.PL PREFIX="%{buildroot}%{_prefix}" INSTALLDIRS="vendor"
 
 %install
+# HTTP and web files
 %{__install} -d -p %{buildroot}%{_datadir}/resourcedb/www/static
 
 cp -ar www/static/* %{buildroot}%{_datadir}/resourcedb/www/static
 
-%check
-make test_jenkins
+# Configuration and schema files
+%{__install} -d -p %{buildroot}%{_sysconfdir}/grnoc/resourcedb
+
+%{__install} -m 544 sql/resourcedb.sql %{buildroot}%{_sysconfdir}/grnoc/resourcedb
+
+# Executables
+%{__install} -d -p %{buildroot}%{_bindir}/grnoc/resourcedb
+
+%{__install} -m 544 bin/resourcedb-init-db %{buildroot}%{_bindir}
+
+#%check
+#make test_jenkins
 
 %clean
 rm -rf $RPM_BUILD_ROOT
 
 %files
 %{_datadir}/resourcedb/www/static/
+%{_sysconfdir}/grnoc/resourcedb/resourcedb.sql
+%{_bindir}/resourcedb-init-db

--- a/resourcedb.spec
+++ b/resourcedb.spec
@@ -43,8 +43,8 @@ cp -ar www/static/* %{buildroot}%{_datadir}/resourcedb/www/static
 
 %{__install} -m 544 bin/resourcedb-init-db %{buildroot}%{_bindir}
 
-#%check
-#make test_jenkins
+%check
+make test_jenkins
 
 %clean
 rm -rf $RPM_BUILD_ROOT


### PR DESCRIPTION
The init script creates the `rdb` user which has full access to the `resourcedb` and `resourcedbtest` databases; It then stores this information in configuration file for later use.